### PR TITLE
Run editor within shell

### DIFF
--- a/packages/core/src/voteUsingGit.ts
+++ b/packages/core/src/voteUsingGit.ts
@@ -60,7 +60,7 @@ export async function voteAndCommit({
       console.log("Ballot is ready for edit.");
       await runChildProcessAsync(EDITOR, [
         path.join(cwd, subPath, `${handle || username}.yml`),
-      ]);
+      ], { spawnArgs: { shell: true } });
       rawBallot = await fs.readFile(
         path.join(cwd, subPath, `${handle || username}.yml`)
       );


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node-core-utils/issues/803

after debugging, I found this is what is done when running `git node land` and works in my case:
https://github.com/nodejs/node-core-utils/blob/39f1002e28e287914774edfd1837bd5059a66559/lib/landing_session.js#L354-L358

fixing this locally has resolved the issue