### PR TITLE
fix(core): use `git restore` to remove vote files

### DIFF
--- a/packages/core/src/countBallotsFromGit.ts
+++ b/packages/core/src/countBallotsFromGit.ts
@@ -239,10 +239,23 @@ export default async function countFromGit({
     } finally {
       await fd.close();
     }
-    await runChildProcessAsync(GIT_BIN, ["add", filepath], { spawnArgs });
 
     // Remove all vote related files.
-    await runChildProcessAsync(GIT_BIN, ["rm", "-rf", subPath], { spawnArgs });
+    await runChildProcessAsync(
+      GIT_BIN,
+      [
+        "restore",
+        "--source",
+        `${firstCommitRef}^`,
+        "--staged",
+        "--worktree",
+        "--",
+        ".",
+      ],
+      { spawnArgs }
+    );
+
+    await runChildProcessAsync(GIT_BIN, ["add", filepath], { spawnArgs });
 
     await runChildProcessAsync(
       GIT_BIN,


### PR DESCRIPTION
There was an assumption that all vote files would be in the same folder, but that doesn't have to be the case. Instead we can use `git restore` to make sure all the changes are removed.