### PR TITLE
feat(core): add an option to skip pushing init vote commit

### DIFF
--- a/packages/core/src/generateNewVoteFolder.ts
+++ b/packages/core/src/generateNewVoteFolder.ts
@@ -59,6 +59,7 @@ interface Options {
     commitMessage?: string;
     commitAuthor?: string;
     gpgSign?: boolean | string;
+    pushToRemote?: boolean
   };
 }
 
@@ -236,6 +237,7 @@ export default async function generateNewVoteFolder(options: Options) {
       gpgSign,
       commitAuthor,
       commitMessage,
+      pushToRemote = true,
       doNotCleanTempFiles,
     } = gitOptions;
     const spawnArgs = { cwd: directory };
@@ -264,7 +266,7 @@ export default async function generateNewVoteFolder(options: Options) {
       { spawnArgs }
     );
 
-    if (repo) {
+    if (repo && pushToRemote) {
       await runChildProcessAsync(GIT_BIN, ["push", repo, `HEAD:${branch}`], {
         spawnArgs,
       });


### PR DESCRIPTION
There could be some scenario where having Caritat push the init commit suboptimal, e.g. when a vote is created using GHA, the only practical way to have a signed commit is to use the GitHub GraphQL API, not the `git` interface.