### PR TITLE
fix(core): do not crash the vote count in case of invalid ballot

### DIFF
--- a/packages/core/src/vote.ts
+++ b/packages/core/src/vote.ts
@@ -143,7 +143,7 @@ export default class Vote {
   }
 
   public addBallotFile(ballotData: BallotFileFormat, author?: string): Ballot {
-    if (checkBallot(ballotData, this.voteFileData, author)) {
+    if (ballotData && checkBallot(ballotData, this.voteFileData, author)) {
       const preferences: Map<VoteCandidate, Rank> = new Map(
         ballotData.preferences.map((element) => [element.title, element.score])
       );
@@ -154,7 +154,7 @@ export default class Vote {
       this.addBallot(ballot);
       return ballot;
     } else {
-      console.warn("Invalid Ballot");
+      console.warn("Invalid Ballot", author);
     }
     return null;
   }


### PR DESCRIPTION
If the ballot contains invalid YAML syntax, `ballotData` is `undefined`, and the script throws a very obscure error.