### PR TITLE
fix(web-ui): shuffling candidates with line returns

### DIFF
--- a/packages/web-ui/src/fetchDataFromGitHub.ts
+++ b/packages/web-ui/src/fetchDataFromGitHub.ts
@@ -226,6 +226,10 @@ async function act(
                 for (;;) {
                   lineStart = lineEnd + 1;
                   lineEnd = ballotData.indexOf("\n", lineStart);
+                  if (lineEnd === lineStart) {
+                    currentCandidate += '\n';
+                    continue;
+                  }
                   if (lineEnd === -1) {
                     if (lineStart !== ballotData.length) {
                       currentCandidate += ballotData.slice(lineStart - 1);


### PR DESCRIPTION
If the list contains empty lines, we can directly go to the next line.