### PR TITLE
feat(chore): add option to strip additional lines in summary

### DIFF
--- a/packages/core/src/countBallotsFromGit.ts
+++ b/packages/core/src/countBallotsFromGit.ts
@@ -233,7 +233,7 @@ export default async function countFromGit({
 
   await Promise.all(decryptPromises);
 
-  const result = vote.count({ discardedCommits });
+  const result = vote.count({ discardedCommits, keepOnlyFirstLineInSummary: vote.voteFileData.keepOnlyFirstLineInSummary });
 
   if (commitJsonSummary != null) {
     if (lastCommitRef !== "HEAD") {

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -16,6 +16,7 @@ export interface VoteFileFormat {
   checksum?: string;
 
   canShuffleCandidates?: boolean;
+  keepOnlyFirstLineInSummary?: boolean;
   requireSignedBallots?: boolean;
 }
 function instanceOfVoteFile(object): object is VoteFileFormat {

--- a/packages/core/src/summary/condorcetSummary.ts
+++ b/packages/core/src/summary/condorcetSummary.ts
@@ -73,7 +73,10 @@ interface BallotSummarize {
   minCandidates?: VoteCandidate[];
   orderedCandidates?: VoteCandidate[][];
 }
-export function getSummarizedBallot(ballot: Ballot): BallotSummarize {
+export function getSummarizedBallot(
+  ballot: Ballot,
+  keepOnlyFirstLineInSummary?: boolean
+): BallotSummarize {
   let maxNote = Number.MIN_SAFE_INTEGER;
   let minNote = Number.MAX_SAFE_INTEGER;
   for (const [, score] of ballot.preferences) {
@@ -91,7 +94,8 @@ export function getSummarizedBallot(ballot: Ballot): BallotSummarize {
       for (const [candidate, score] of ballot.preferences) {
         const candidatesForThisScore = orderedPreferences.get(score);
         const markdownCandidate = `**${cleanMarkdown(
-          candidate.replace(/\.$/, "")
+          candidate,
+          keepOnlyFirstLineInSummary
         )}**`;
         if (candidatesForThisScore == null) {
           orderedPreferences.set(score, [markdownCandidate]);
@@ -106,7 +110,7 @@ export function getSummarizedBallot(ballot: Ballot): BallotSummarize {
       };
     }
     const group = score === minNote ? minCandidates : maxCandidates;
-    group.push(`**${cleanMarkdown(candidate).replace(/\.$/, "")}**`);
+    group.push(`**${cleanMarkdown(candidate, keepOnlyFirstLineInSummary)}**`);
   }
   return { minCandidates, maxCandidates };
 }
@@ -116,7 +120,7 @@ export default class CondorcetElectionSummary extends ElectionSummary {
 
   summarizeBallot(ballot: Ballot) {
     return summarizeCondorcetBallotForElectionSummary(
-      getSummarizedBallot(ballot),
+      getSummarizedBallot(ballot, this.keepOnlyFirstLineInSummary),
       4
     );
   }

--- a/packages/core/src/utils/cleanMarkdown.ts
+++ b/packages/core/src/utils/cleanMarkdown.ts
@@ -3,7 +3,14 @@ function cleanUnsupportedMarkdown(txt: string): string {
   return txt.replace(/([_~*\\[\]<>`])/g, "\\$1");
 }
 
-export default function cleanMarkdown(txt: string): string {
+function reduceToFirstLine(candidate: string) {
+  const i = candidate.indexOf('\n')
+  return i === -1 ? candidate : candidate.slice(0, i - Number(candidate[i] === '.' || candidate === ':'));
+}
+export default function cleanMarkdown(txt: string, keepOnlyFirstLineInSummary?: boolean): string {
+  if (keepOnlyFirstLineInSummary) txt = reduceToFirstLine(txt);
+  else if (txt.endsWith('.') || txt.endsWith(':')) txt = txt.slice(0, -1);
+
   // Escape backticks for edge case scenarii (no code span support).
   if (txt.includes("``") || txt.includes("\\`")) {
     return cleanUnsupportedMarkdown(txt);


### PR DESCRIPTION
It can be useful to add additional context to the vote candidate, but that can make the vote (or ballot) summary quite hard to decipher. This PR adds the possibility to declare `keepOnlyFirstLineInSummary: true` in the `vote.yml` file.