### PR TITLE
feat(core): Allow GPG parameters and ignore git hooks.

### DIFF
--- a/packages/cli/src/bin/decryptKeyPart.ts
+++ b/packages/cli/src/bin/decryptKeyPart.ts
@@ -60,10 +60,15 @@ if (argv[2] === "-h" || argv[2] === "--help") {
 
 const { shares } = yaml.load(yamlString) as VoteFileFormat;
 const ac = new AbortController();
+const gpgParams = (process.env.CARITAT_GPG_PARAMS ?? "").split(/\s/g);
 const out = await Promise.any(
   shares.map(async (share) => {
-    const cp = spawn(env.GPG_BIN || "gpg", ["-d"], {
-      stdio: ["pipe", "pipe", "inherit"],
+    const cp = spawn(env.GPG_BIN || "gpg", ["-d", ...gpgParams], {
+      stdio: [
+        "pipe",
+        "pipe",
+        process.env.CARITAT_SHOW_ERRORS ? "inherit" : "ignore",
+      ],
       signal: ac.signal,
     });
     const stdout = cp.stdout.toArray();

--- a/sh/voteUsingGit.sh
+++ b/sh/voteUsingGit.sh
@@ -32,7 +32,7 @@ $EDITOR "$tmpDir/$path/ballot.yml"
 # Commit the encrypted JSON vote data.
 (cd "$tmpDir" && \
   git add "$tmpDir/$path/$username.json" && \
-  git commit -m "vote from $username")
+  git commit -n -m "vote from $username")
 
 # Pushing to the remote repository.
 (cd "$tmpDir" && \


### PR DESCRIPTION
This PR introduces the follow changes:

1. Add `-n` when committing votes. This avoids to being unexpectedly blocked by custom hooks.
2. Add `CARITAT_GPG_PARAMS` environment variable to customize GPG when decrypting the ballot. This is to handle exotic configurations (like mine where the spinner in `git node vote` was interfering with password prompt)
3. Add `CARITAT_SHOW_ERRORS` environment variable to explicitly opt-in for errors showing. This is to cleanup the output when decrypting the ballot since all but one promises are expected to fail.