### PR TITLE
chore: review use of `as` keyword in codebase

### DIFF
--- a/packages/cli/src/bin/countBallotsFromGit.ts
+++ b/packages/cli/src/bin/countBallotsFromGit.ts
@@ -25,7 +25,7 @@ const { repo: repoURL, branch, path: subPath } = parsedArgs;
 const privateKey
   = parsedArgs.key === "-"
     ? await readStdIn(false)
-    : parsedArgs.key && (await fs.readFile(parsedArgs.key as string));
+    : parsedArgs.key && (await fs.readFile(parsedArgs.key));
 
 const { result, privateKeyAsArmoredString } = await countFromGit({
   ...(await getEnv(parsedArgs)),

--- a/packages/cli/src/bin/voteOnGitHub.ts
+++ b/packages/cli/src/bin/voteOnGitHub.ts
@@ -89,7 +89,7 @@ const query = `query PR($prid: Int!, $owner: String!, $repo: String!) {
 console.log("Getting info from GitHub API...");
 const { data } = JSON.parse(
   await runChildProcessAsync(
-    parsedArgs["gh-binary"] as string,
+    parsedArgs["gh-binary"],
     [
       "api",
       "graphql",
@@ -122,7 +122,7 @@ if (merged || closed) {
 
 console.log(`Locating vote.yml on commit ${sha}...`);
 const files = await runChildProcessAsync(
-  parsedArgs["gh-binary"] as string,
+  parsedArgs["gh-binary"],
   [
     "api",
     `/repos/${owner}/${repo}/commits/${sha}`,

--- a/packages/cli/src/utils/countBallotsGitEnv.ts
+++ b/packages/cli/src/utils/countBallotsGitEnv.ts
@@ -30,7 +30,7 @@ export const cliArgs = {
 };
 
 export async function getEnv(parsedArgs: GitCliArgsType) {
-  const GIT_BIN = (parsedArgs["git-binary"] ?? env.GIT ?? "git") as string;
+  const GIT_BIN = (parsedArgs["git-binary"] ?? env.GIT ?? "git");
 
   const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "caritat-"));
   return {

--- a/packages/cli/src/utils/runChildProcessAsync.ts
+++ b/packages/cli/src/utils/runChildProcessAsync.ts
@@ -6,7 +6,7 @@ export default (
   args: any[] | readonly string[],
   { captureStdout = false, captureStderr = false, spawnArgs = {} } = {},
 ) =>
-  new Promise((resolve, reject) => {
+  new Promise<string>((resolve, reject) => {
     const opt = {
       stdio: captureStdout
         ? (["inherit", "pipe", "inherit"] as IOType[])
@@ -37,4 +37,4 @@ export default (
       }
       return resolve(stdout?.trim());
     });
-  }) as Promise<string>;
+  });

--- a/packages/cli/src/utils/streamChildProcessStdout.ts
+++ b/packages/cli/src/utils/streamChildProcessStdout.ts
@@ -12,7 +12,7 @@ export default async function* streamChildProcessStdout(
     stdio: ["inherit", "pipe", "inherit"],
     ...spawnArgs,
   });
-  const promise = new Promise((resolve, reject) => {
+  const promise = new Promise<void>((resolve, reject) => {
     child.once("error", reject);
     child.on("close", (code) => {
       if (code !== 0) {
@@ -20,7 +20,7 @@ export default async function* streamChildProcessStdout(
       }
       resolve();
     });
-  }) as Promise<void>;
+  });
   yield* createInterface({ input: child.stdout });
   return promise;
 }

--- a/packages/core/src/countBallotsFromGit.ts
+++ b/packages/core/src/countBallotsFromGit.ts
@@ -54,13 +54,13 @@ async function readFileAtRevision(
   );
 }
 
-interface countFromGitArgs {
+interface countFromGitArgs<T extends BufferSource> {
   GIT_BIN?: string;
   cwd: string;
   repoURL: string;
   branch: string;
   subPath: string;
-  privateKey?: ArrayBuffer;
+  privateKey?: T;
   keyParts: string[];
   firstCommitRef: string;
   lastCommitRef?: string;
@@ -71,7 +71,7 @@ interface countFromGitArgs {
   doNotCleanTempFiles: boolean;
 }
 
-export default async function countFromGit({
+export default async function countFromGit<T extends BufferSource = BufferSource>({
   GIT_BIN = "git",
   cwd,
   repoURL,
@@ -86,9 +86,9 @@ export default async function countFromGit({
   pushToRemote = true,
   gpgSign,
   doNotCleanTempFiles,
-}: countFromGitArgs): Promise<{
+}: countFromGitArgs<T>): Promise<{
     result: VoteResult;
-    privateKey: ArrayBuffer;
+    privateKey: T;
     readonly privateKeyAsArmoredString: string;
   }> {
   const spawnArgs = { cwd };
@@ -150,7 +150,7 @@ export default async function countFromGit({
       keyParts?.map((part: string | BufferSource) =>
         typeof part === "string" ? Buffer.from(part, "base64") : part,
       ),
-    );
+    ) as T;
   }
 
   if (mailmap != null) {
@@ -343,7 +343,7 @@ export default async function countFromGit({
     result,
     privateKey,
     get privateKeyAsArmoredString() {
-      const base64Key = Buffer.from(privateKey).toString("base64");
+      const base64Key = Buffer.from(privateKey as ArrayBuffer).toString("base64");
       let key = "-----BEGIN PRIVATE KEY-----\n";
       for (let i = 0; i < base64Key.length; i += 64) {
         key += base64Key.slice(i, i + 60) + "\n";

--- a/packages/core/src/utils/runChildProcessAsync.ts
+++ b/packages/core/src/utils/runChildProcessAsync.ts
@@ -11,7 +11,7 @@ export default (
     spawnArgs = {},
   } = {},
 ) =>
-  new Promise((resolve, reject) => {
+  new Promise<string>((resolve, reject) => {
     const opt = {
       stdio: captureStdout
         ? (["inherit", "pipe", "inherit"] as IOType[])
@@ -42,4 +42,4 @@ export default (
       }
       return resolve(trimOutput ? stdout?.trim() : stdout);
     });
-  }) as Promise<string>;
+  });

--- a/packages/core/src/utils/streamChildProcessStdout.ts
+++ b/packages/core/src/utils/streamChildProcessStdout.ts
@@ -12,7 +12,7 @@ export default async function* streamChildProcessStdout(
     stdio: ["inherit", "pipe", "inherit"],
     ...spawnArgs,
   });
-  const promise = new Promise((resolve, reject) => {
+  const promise = new Promise<void>((resolve, reject) => {
     child.once("error", reject);
     child.on("close", (code) => {
       if (code !== 0) {
@@ -20,7 +20,7 @@ export default async function* streamChildProcessStdout(
       }
       resolve();
     });
-  }) as Promise<void>;
+  });
   yield* createInterface({ input: child.stdout });
   return promise;
 }

--- a/packages/crypto/src/decrypt.ts
+++ b/packages/crypto/src/decrypt.ts
@@ -20,7 +20,7 @@ export async function symmetricDecrypt(
   const { byteLength } = saltedCiphertext;
   if (ArrayBuffer.isView(saltedCiphertext)) {
     offset = saltedCiphertext.byteOffset;
-    saltedCiphertext = saltedCiphertext.buffer;
+    saltedCiphertext = saltedCiphertext.buffer as ArrayBuffer;
   }
 
   const magicNumber = new DataView(saltedCiphertext, offset, 8);


### PR DESCRIPTION
With the TS update, there are a few occurences we could clean out