### PR TITLE
chore(ci): fix build error not being reported

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "test:lint": "eslint .",
-    "test:types": "tsc --build --noEmit",
+    "test:types": "tsc --build --emitDeclarationOnly",
     "test:unit": "node --experimental-global-webcrypto --loader '#ts-loader' test/index.ts",
     "test": "yarn test:lint && yarn test:types && yarn test:unit",
     "build": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "test:lint": "eslint .",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --build --noEmit",
     "test:unit": "node --experimental-global-webcrypto --loader '#ts-loader' test/index.ts",
     "test": "yarn test:lint && yarn test:types && yarn test:unit",
     "build": "tsc --build",


### PR DESCRIPTION
Without the `--build`, we were only testing top-level `.ts` files.