### PR TITLE
feat(core): pass `--no-verify` flag to `git commit`

### DIFF
--- a/packages/core/src/countBallotsFromGit.ts
+++ b/packages/core/src/countBallotsFromGit.ts
@@ -288,6 +288,7 @@ export default async function countFromGit<T extends BufferSource = BufferSource
       GIT_BIN,
       [
         "commit",
+        "-n",
         ...getGPGSignGitFlag(gpgSign),
         "-m",
         `close vote and aggregate results`,

--- a/packages/core/src/generateNewVoteFolder.ts
+++ b/packages/core/src/generateNewVoteFolder.ts
@@ -253,6 +253,7 @@ export default async function generateNewVoteFolder(options: Options) {
       GIT_BIN,
       [
         "commit",
+        "-n",
         ...(gpgSign === true
           ? ["-S"]
           : typeof gpgSign === "string"

--- a/packages/core/src/voteUsingGit.ts
+++ b/packages/core/src/voteUsingGit.ts
@@ -128,6 +128,7 @@ export async function voteAndCommit({
     GIT_BIN,
     [
       "commit",
+      "-n",
       ...getGPGSignGitFlag(gpgSign),
       `--author`,
       author,

--- a/sh/voteUsingGit.ps1
+++ b/sh/voteUsingGit.ps1
@@ -22,7 +22,7 @@ Set-Location "$tmpDir/$path"
 
 
 git add "$username.json" | Out-Null
-git commit -m "vote from $username" | Out-Null
+git commit -n -m "vote from $username" | Out-Null
 
 git push "$repoUrl" "HEAD:$branch" | Out-Null
 

--- a/sh/voteUsingGit.sh
+++ b/sh/voteUsingGit.sh
@@ -32,7 +32,7 @@ $EDITOR "$tmpDir/$path/ballot.yml"
 # Commit the encrypted JSON vote data.
 (cd "$tmpDir" && \
   git add "$tmpDir/$path/$username.json" && \
-  git commit -m "vote from $username")
+  git commit -n -m "vote from $username")
 
 # Pushing to the remote repository.
 (cd "$tmpDir" && \


### PR DESCRIPTION
This avoids to being unexpectedly blocked by custom hooks.

Suggested by @ShogunPanda in https://github.com/nodejs/caritat/pull/60.